### PR TITLE
fix: refresh indicator takes a future to complete

### DIFF
--- a/lib/src/river_paged_builder.dart
+++ b/lib/src/river_paged_builder.dart
@@ -158,7 +158,7 @@ class _RiverPagedBuilderState<PageKeyType, ItemType>
     // Add pull to refresh functionality if specified
     if (widget.pullToRefresh) {
       pagedBuilder = RefreshIndicator(
-          onRefresh: () => ref.refresh(_provider), child: pagedBuilder);
+          onRefresh: () async => ref.refresh(_provider), child: pagedBuilder);
     }
 
     return pagedBuilder;


### PR DESCRIPTION
## Issue

The `onRefresh` argument on `RefreshIndicator` requires a `Future` in order for it hide the indicator when the refreshing is done.

## Solution

Making the function an `async` function ensures the indicator will hide when finished.