### PR TITLE
Print stacktrace

### DIFF
--- a/lib/src/paged_notifier.dart
+++ b/lib/src/paged_notifier.dart
@@ -23,10 +23,14 @@ class PagedNotifier<PageKeyType, ItemType>
   /// A builder for providing a custom error string
   final String? Function(dynamic error)? errorBuilder;
 
+  /// A builder for providing a custom error string
+  final bool printStackTrace;
+
   PagedNotifier(
       {required LoadFunction<PageKeyType, ItemType> load,
       required this.nextPageKeyBuilder,
-      this.errorBuilder})
+      this.errorBuilder,
+      this.printStackTrace = false})
       : _load = load,
         super(PagedState<PageKeyType, ItemType>());
 
@@ -56,7 +60,7 @@ class PagedNotifier<PageKeyType, ItemType>
                 ? errorBuilder!(e)
                 : 'Si è verificato un\'errore. Per favore riprovare.');
         debugPrint(e.toString());
-        debugPrint(stacktrace.toString());
+        if (printStackTrace) { debugPrint(stacktrace.toString()); }
       }
     }
     return null;

--- a/lib/src/paged_notifier.dart
+++ b/lib/src/paged_notifier.dart
@@ -49,13 +49,14 @@ class PagedNotifier<PageKeyType, ItemType>
           nextPageKey: nextPageKeyBuilder(records, page, limit),
           previousPageKeys: {...state.previousPageKeys, page}.toList());
       return records;
-    } catch (e) {
+    } catch (e, stacktrace) {
       if (mounted) {
         state = state.copyWith(
             error: errorBuilder != null
                 ? errorBuilder!(e)
                 : 'Si è verificato un\'errore. Per favore riprovare.');
         debugPrint(e.toString());
+        debugPrint(stacktrace.toString());
       }
     }
     return null;


### PR DESCRIPTION
Sometimes exception messages are useless e.g. `Expected a value of type 'String', but got one of type 'Null'`