### PR TITLE
Changed return type of errorBuilder to dynamic

### DIFF
--- a/lib/src/paged_notifier.dart
+++ b/lib/src/paged_notifier.dart
@@ -21,7 +21,7 @@ class PagedNotifier<PageKeyType, ItemType>
   final NextPageKeyBuilder<PageKeyType, ItemType> nextPageKeyBuilder;
 
   /// A builder for providing a custom error string
-  final String? Function(dynamic error)? errorBuilder;
+  final dynamic Function(dynamic error)? errorBuilder;
 
   PagedNotifier(
       {required LoadFunction<PageKeyType, ItemType> load,

--- a/lib/src/paged_notifier.dart
+++ b/lib/src/paged_notifier.dart
@@ -54,7 +54,7 @@ class PagedNotifier<PageKeyType, ItemType>
         state = state.copyWith(
             error: errorBuilder != null
                 ? errorBuilder!(e)
-                : 'Si è verificato un\'errore. Per favore riprovare.');
+                : 'An error occurred. Please try again.');
         debugPrint(e.toString());
       }
     }


### PR DESCRIPTION
I have to pass original error to the `PagingController`. Example of usage:

```dart
  RiverPagedBuilder(
      firstPageErrorIndicatorBuilder: (context, controller) {
        return ErrorBox(
          message: ErrorMessage.byException(controller.error),
          onTryAgain: controller.retryLastFailedRequest,
        );
      },
```