### PR TITLE
relax riverpod dependency constraint and pub upgrade `example`

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -61,7 +61,7 @@ packages:
       name: flutter_riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -80,7 +80,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   matcher:
     dependency: transitive
     description:
@@ -115,7 +115,7 @@ packages:
       name: riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.1"
   riverpod_infinite_scroll:
     dependency: "direct main"
     description:
@@ -134,7 +134,7 @@ packages:
       name: sliver_tools
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.8"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   collection: ^1.16.0
   flutter:
     sdk: flutter
-  flutter_riverpod: ^2.0.0
+  flutter_riverpod: ">=2.0.0 <2.2.0"
   infinite_scroll_pagination: ^3.2.0
 
 dev_dependencies:


### PR DESCRIPTION
This allows for the usage of this library without being as specific in regard to riverpod version.

This way people can use libraries in their project without breaking `pub get` in case they use other library that depends on a different riverpod version.

There were no breaking changes introduced in riverpod since 2.0.0 and I'm pretty sure it will stay the same until 3.0.0 but just to be on the safe side I've set the upper constraint to a pretty conservative 2.2.0